### PR TITLE
Relax /api/flags test

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,11 +28,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           max_timeout: 300
       - name: Run Playwright tests
-        run: npm run test:e2e
+        run: npm run e2e
         env:
           BASE_URL: ${{ steps.waitForDeploy.outputs.url }}
-          EDGE_CONFIG: ${{ secrets.EDGE_CONFIG }}
-          VERCEL_ENV: preview
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "conventionalCommits.scopes": ["next.js", "home", "maintenance"],
+  "conventionalCommits.scopes": ["next.js", "home", "maintenance", "api"],
   "files.associations": {
     "*.css": "tailwindcss"
   },

--- a/e2e/api/flags/route.spec.ts
+++ b/e2e/api/flags/route.spec.ts
@@ -4,9 +4,12 @@ test("should return the feature flags successfully", async ({ request }) => {
   const flags = await request.get("/api/flags");
   expect(flags.ok()).toBeTruthy();
   expect(flags.status()).toBe(200);
-  // Note, playwright tests are run against the preview environment. Tests will fail if the preview feature flags are altered.
-  expect(await flags.json()).toEqual({
-    beta: true,
-    maintenance: false,
-  });
+
+  // Note: playwright tests are run against live environments
+  expect(await flags.json()).toEqual(
+    expect.objectContaining({
+      beta: expect.any(Boolean),
+      maintenance: expect.any(Boolean),
+    }),
+  );
 });

--- a/package.json
+++ b/package.json
@@ -6,16 +6,15 @@
     "analyze": "cross-env ANALYZE=true npm run build",
     "build": "next build",
     "dev": "next dev",
-    "dev:test": "cross-env VERCEL=preview npm run dev",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
     "format": "prettier --write .",
     "preinstall": "npx npm-only-allow@latest --PM npm",
     "lint": "next lint",
     "prepare": "husky install",
     "start": "next start",
     "test": "jest --watch",
-    "test:ci": "jest --ci",
-    "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:ci": "jest --ci"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -67,7 +67,7 @@ export default defineConfig({
   webServer: env.CI
     ? undefined
     : {
-        command: "npm run dev:test",
+        command: "npm run dev",
         url: baseURL,
         timeout: 120 * 1000,
         reuseExistingServer: true,


### PR DESCRIPTION
Relax the e2e tests for /api/flags to include the correct flags, but not match their exact values.