### PR TITLE
Limit renovate PRs to 4

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>SVendittelli/renovate-config"]
+  "extends": ["github>SVendittelli/renovate-config"],
+  "prConcurrentLimit": 4
 }


### PR DESCRIPTION
So we don't exhaust all of neon DB's branches, limit renovate PRs to 4.