### PR TITLE
Increase database connection timeout

### DIFF
--- a/prisma/.env
+++ b/prisma/.env
@@ -1,3 +1,3 @@
 # Vercel does not support environment variable expansion so these need to be expanded by prisma
-DATABASE_URL_DIRECT="${DATABASE_URL}?sslmode=require"
-DATABASE_URL_WITH_POOLING="${DATABASE_URL}?sslmode=require&pgbouncer=true"
+DATABASE_URL_DIRECT="${DATABASE_URL}?sslmode=require&connect_timeout=10"
+DATABASE_URL_WITH_POOLING="${DATABASE_URL}?sslmode=require&connect_timeout=10&pgbouncer=true"


### PR DESCRIPTION
Performing DB migrations from cold start is timing out in some builds, increase the timeout to 10 seconds from 5.