### PR TITLE
Group devdependency updates together

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>SVendittelli/renovate-config"],
-  "prConcurrentLimit": 4
+  "prConcurrentLimit": 4,
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "updateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "devDependencies",
+      "automerge": true
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,11 +7,12 @@
     "db",
     "git",
     "analytics",
-    "adr"
+    "adr",
+    "deps"
   ],
   "files.associations": {
     "*.css": "tailwindcss"
   },
   "typescript.tsdk": "node_modules\\typescript\\lib",
-  "cSpell.words": ["datasources", "dockerized"]
+  "cSpell.words": ["automerge", "datasources", "dockerized"]
 }


### PR DESCRIPTION
To reduce the number of small PRs, group all dev dependency updates together.