### PR TITLE
Set production url to custom domain

### DIFF
--- a/lib/branding.ts
+++ b/lib/branding.ts
@@ -8,4 +8,7 @@ export const description =
 /**
  * The base URL of the application. This is used for generating absolute URLs
  */
-export const baseUrl = env.VERCEL_URL;
+export const baseUrl =
+  env.VERCEL_ENV === "production"
+    ? "https://halloween.vendittelli.co.uk/"
+    : env.VERCEL_URL;


### PR DESCRIPTION
Using the vercel URL directly results in incorrect links in production.