### PR TITLE
feat(storybook): exit after upload

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -25,3 +25,4 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          exitOnceUploaded: true


### PR DESCRIPTION
GitHub is integrated with Chromatic and will report statuses on commits. We can save some CI time by not waiting for the results as part of this flow.