### PR TITLE
test(sample-data): fix test regex

### DIFF
--- a/app/demo/sample-data.test.tsx
+++ b/app/demo/sample-data.test.tsx
@@ -17,7 +17,7 @@ describe("sampleData", () => {
   it("contains only movies with posters", () => {
     sampleData.forEach((movie) => {
       expect(movie.poster).toBeDefined();
-      expect(movie.poster).toMatch(/^https?:\/\/m.media-amazon.com/);
+      expect(movie.poster).toMatch(/^https?:\/\/m\.media-amazon\.com/);
     });
   });
 


### PR DESCRIPTION
### Description<!-- markdownlint-disable-line MD041 -->

The dots in the URL should match with the literal . not any character.
